### PR TITLE
GHC 7.6 removed support for type operators as type variables.

### DIFF
--- a/TypeCompose.cabal
+++ b/TypeCompose.cabal
@@ -1,5 +1,5 @@
 Name:                TypeCompose
-Version:             0.9.6
+Version:             0.9.7
 Synopsis: 	     Type composition classes & instances
 Category:            Composition, Control
 Cabal-Version:       >= 1.6

--- a/src/Data/Bijection.hs
+++ b/src/Data/Bijection.hs
@@ -33,7 +33,7 @@ infix 8 :<->:
 infixr 2 --->
 
 -- | A type of bijective arrows
-data Bijection (~>) a b = Bi { biTo :: a ~> b, biFrom :: b ~> a }
+data Bijection j a b = Bi { biTo :: a `j` b, biFrom :: b `j` a }
 
 -- | Bijective functions
 type a :<->: b = Bijection (->) a b
@@ -41,20 +41,20 @@ type a :<->: b = Bijection (->) a b
 -- | Bijective identity arrow.  Warning: uses 'arr' on @(~>)@.  If you
 -- have no 'arr', but you have a @DeepArrow@, you can instead use @Bi idA
 -- idA@.
-idb :: Arrow (~>) => Bijection (~>) a a
+idb :: Arrow j => Bijection j a a
 idb = Bi idA idA where idA = arr id
 
 -- | Inverse bijection
-inverse :: Bijection (~>) a b -> Bijection (~>) b a
+inverse :: Bijection j a b -> Bijection j b a
 inverse (Bi ab ba) = Bi ba ab
 
 #if __GLASGOW_HASKELL__ >= 609
-instance Category (~>) => Category (Bijection (~>)) where
+instance Category j => Category (Bijection j) where
   id = Bi id id
   Bi bc cb . Bi ab ba = Bi (bc . ab) (ba . cb)
 #endif
 
-instance Arrow (~>) => Arrow (Bijection (~>)) where
+instance Arrow j => Arrow (Bijection j) where
 #if __GLASGOW_HASKELL__ < 609
   Bi ab ba >>> Bi bc cb = Bi (ab >>> bc) (cb >>> ba)
 #endif
@@ -75,8 +75,8 @@ bimap :: Functor f => (a :<->: b) -> (f a :<->: f b)
 bimap (Bi ab ba) = Bi (fmap ab) (fmap ba)
 
 -- | Bijections on arrows.
-(--->) :: Arrow (~>) => Bijection (~>) a b -> Bijection (~>) c d
-       -> (a ~> c) :<->: (b ~> d)
+(--->) :: Arrow j => Bijection j a b -> Bijection j c d
+       -> (a `j` c) :<->: (b `j` d)
 Bi ab ba ---> Bi cd dc = Bi (\ ac -> ba>>>ac>>>cd) (\ bd -> ab>>>bd>>>dc)
 
 -- TODO: Rewrite (--->) via (~>).  Currently would cause a module cycle
@@ -85,5 +85,5 @@ Bi ab ba ---> Bi cd dc = Bi (\ ac -> ba>>>ac>>>cd) (\ bd -> ab>>>bd>>>dc)
 
 
 -- | Apply a function in an alternative (monomorphic) representation.
-inBi :: Arrow (~>) => Bijection (~>) a b -> (a ~> a) -> (b ~> b)
+inBi :: Arrow j => Bijection j a b -> (a `j` a) -> (b `j` b)
 inBi (Bi to from) aa = from >>> aa >>> to

--- a/src/Data/Lambda.hs
+++ b/src/Data/Lambda.hs
@@ -93,13 +93,13 @@ instance (Lambda src snk, Lambda dom' ran')
 
 -- | 'lambda' with 'Arrw'.  /Warning/: definition uses 'arr', so only
 -- use if your arrow has a working 'arr'.
-arLambda :: (Arrow (~>), Unlambda f f', Lambda g g')
-      => LambdaTy (Arrw (~>) f g) (Arrw (~>) f' g')
+arLambda :: (Arrow j, Unlambda f f', Lambda g g')
+      => LambdaTy (Arrw j f g) (Arrw j f' g')
 arLambda = inArrw2 $ \ fga fgb ->
   arr unlambda >>> fga***fgb >>> arr (uncurry lambda)
 
-instance (Arrow (~>), Unlambda f f', Lambda g g')
-    => Lambda (Arrw (~>) f g) (Arrw (~>) f' g')
+instance (Arrow j, Unlambda f f', Lambda g g')
+    => Lambda (Arrw j f g) (Arrw j f' g')
   where lambda = arLambda
 
 

--- a/src/Data/Pair.hs
+++ b/src/Data/Pair.hs
@@ -95,8 +95,8 @@ instance Pair Id where Id a `pair` Id b = Id (a,b)
 -- Standard instance, e.g., (~>) = (->)
 -- This one requires UndecidableInstances.  Alternatively, specialize to
 -- (->) and other arrows as desired.
-instance (Arrow (~>), Monoid_f (Flip (~>) o)) =>
-  Pair (Flip (~>) o) where pair = copair
+instance (Arrow j, Monoid_f (Flip j o)) =>
+  Pair (Flip j o) where pair = copair
 
 -- | Handy for 'Pair' instances
 apPair :: (Applicative h, Pair f) => PairTy (h :. f)
@@ -108,12 +108,12 @@ ppPair = inO2 $ \ gfa gfb -> uncurry pair <$> (gfa `pair` gfb)
 
 -- | Pairing of 'Arrw' values.  /Warning/: definition uses 'arr', so only
 -- use if your arrow has a working 'arr'.
-arPair :: (Arrow (~>), Unpair f, Pair g) => PairTy (Arrw (~>) f g)
+arPair :: (Arrow j, Unpair f, Pair g) => PairTy (Arrw j f g)
 arPair = inArrw2 $ \ fga fgb ->
   arr unpair >>> fga***fgb >>> arr (uncurry pair)
 
 -- Standard instance
-instance (Arrow (~>), Unpair f, Pair g) => Pair (Arrw (~>) f g)
+instance (Arrow j, Unpair f, Pair g) => Pair (Arrw j f g)
   where pair = arPair
 
 instance (Pair f, Pair g) => Pair (f :*: g) where
@@ -175,7 +175,7 @@ instance Copair (Const e) where
   cosnds = inConst id
 
 -- Standard instance for contravariant functors
-instance Arrow (~>) => Copair (Flip (~>) o) where
+instance Arrow j => Copair (Flip j o) where
   { cofsts = contraFmap fst ; cosnds = contraFmap snd }
 
 instance (Functor h, Copair f) => Copair (h :. f) where

--- a/src/Data/Zip.hs
+++ b/src/Data/Zip.hs
@@ -126,8 +126,8 @@ instance Zip Id where Id a `zip` Id b = Id (a,b)
 -- Standard instance, e.g., (~>) = (->)
 -- This one requires UndecidableInstances.  Alternatively, specialize to
 -- (->) and other arrows as desired.
-instance (Arrow (~>), Monoid_f (Flip (~>) o)) =>
-  Zip (Flip (~>) o) where zip = cozip
+instance (Arrow j, Monoid_f (Flip j o)) =>
+  Zip (Flip j o) where zip = cozip
 
 -- | Handy for 'Zip' instances
 apZip :: (Applicative h, Zip f) => ZipTy (h :. f)
@@ -139,12 +139,12 @@ ppZip = inO2 $ \ gfa gfb -> uncurry zip <$> (gfa `zip` gfb)
 
 -- | Ziping of 'Arrw' values.  /Warning/: definition uses 'arr', so only
 -- use if your arrow has a working 'arr'.
-arZip :: (Arrow (~>), Unzip f, Zip g) => ZipTy (Arrw (~>) f g)
+arZip :: (Arrow j, Unzip f, Zip g) => ZipTy (Arrw j f g)
 arZip = inArrw2 $ \ fga fgb ->
   arr unzip >>> fga***fgb >>> arr (uncurry zip)
 
 -- Standard instance
-instance (Arrow (~>), Unzip f, Zip g) => Zip (Arrw (~>) f g)
+instance (Arrow j, Unzip f, Zip g) => Zip (Arrw j f g)
   where zip = arZip
 
 instance (Zip f, Zip g) => Zip (f :*: g) where
@@ -206,7 +206,7 @@ instance Cozip (Const e) where
   cosnds = inConst id
 
 -- Standard instance for contravariant functors
-instance Arrow (~>) => Cozip (Flip (~>) o) where
+instance Arrow j => Cozip (Flip j o) where
   { cofsts = contraFmap fst ; cosnds = contraFmap snd }
 
 instance (Functor h, Cozip f) => Cozip (h :. f) where


### PR DESCRIPTION
Convert all uses of type operators to ordinary type variables, with backtick syntax to replace ordinary infix use.

This is unfortunate, but required to get TypeCompose to compile with GHC 7.6.
