### PR TITLE
Import orphan Monoid instance from base-orphans

### DIFF
--- a/TypeCompose.cabal
+++ b/TypeCompose.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 Library
   Hs-Source-Dirs:      src
-  Build-Depends:       base<5
+  Build-Depends:       base<5, base-orphans
   Exposed-Modules:     
                        Data.Bijection
                        Data.CxMonoid

--- a/src/Control/Compose.hs
+++ b/src/Control/Compose.hs
@@ -6,8 +6,6 @@
 -- For ghc 6.6 compatibility
 -- {-# OPTIONS -fglasgow-exts -fallow-undecidable-instances #-}
 
-{-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
-
 ----------------------------------------------------------------------
 -- |
 -- Module      :  Control.Compose
@@ -76,6 +74,7 @@ import Control.Arrow
                       hiding (pure)
 #endif
 
+import Data.Orphans ()
 import Data.Monoid
 import Data.Foldable
 import Data.Traversable
@@ -904,12 +903,7 @@ inConst3 f (Const a) = inConst2 (f a)
 
 ---- For Control.Applicative.Endo
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 707
 -- deriving instance Monoid o => Monoid (Const o a)
-instance Monoid o => Monoid (Const o a) where
-  mempty  = Const mempty
-  mappend = inConst2 mappend
-#endif
 
 -- newtype Endo a = Endo { appEndo :: a -> a }
 


### PR DESCRIPTION
This consolidates `TypeCompose`'s orphan `Monoid (Const o a)` instance with the one in `base-orphans` (similar to my earlier pull request for [`functor-combo`](https://github.com/conal/functor-combo/pull/2)).