### PR TITLE
Import Monoid IO instance from base-orphans

### DIFF
--- a/TypeCompose.cabal
+++ b/TypeCompose.cabal
@@ -10,7 +10,7 @@ Description:
   Please see the project wiki page: <http://haskell.org/haskellwiki/TypeCompose>
   .
   Copyright 2007-2012 by Conal Elliott; BSD3 license.
-Author:              Conal Elliott 
+Author:              Conal Elliott
 Maintainer:          conal@conal.net
 Homepage:            https://github.com/conal/TypeCompose
 Copyright:           (c) 2007-2013 by Conal Elliott
@@ -25,8 +25,8 @@ source-repository head
 
 Library
   Hs-Source-Dirs:      src
-  Build-Depends:       base<5, base-orphans
-  Exposed-Modules:     
+  Build-Depends:       base<5, base-orphans >= 0.5
+  Exposed-Modules:
                        Data.Bijection
                        Data.CxMonoid
                        Data.RefMonad
@@ -41,4 +41,4 @@ Library
 
   -- TODO: eliminate Pair or Zip
 
---  ghc-prof-options:    -prof -auto-all 
+--  ghc-prof-options:    -prof -auto-all

--- a/src/Control/Instances.hs
+++ b/src/Control/Instances.hs
@@ -1,28 +1,20 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 ----------------------------------------------------------------------
 -- |
 -- Module      :  Control.Instances
 -- Copyright   :  (c) Conal Elliott 2007
 -- License     :  BSD3
--- 
+--
 -- Maintainer  :  conal@conal.net
 -- Stability   :  experimental
 -- Portability :  portable
--- 
+--
 -- Some (orphan) instances that belong elsewhere (where they wouldn't be orphans).
 -- Add the following line to get these instances
--- 
+--
 -- > import Control.Instances ()
--- 
+--
 ----------------------------------------------------------------------
 
 module Control.Instances () where
 
-import Data.Monoid
-import Control.Applicative
-
-
--- Standard instance: Applicative functor applied to monoid
-instance Monoid o => Monoid (IO o) where 
-  mempty  = pure   mempty
-  mappend = liftA2 mappend
+import Data.Orphans ()


### PR DESCRIPTION
Continuing in the same vein as #2, `base-4.9` introduces a `Monoid a => Monoid (IO a)` instance, so it is now provided by `base-orphans`.

These changes make `Control.Instances` little more than a `Data.Orphans` reexport, but I'll keep `Control.Instances` to avoid making a breaking API change.