### PR TITLE
Make (:.) poly-kinded on GHC 7.10+

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, base, base-orphans, stdenv, cabal-install }:
+      mkDerivation {
+        pname = "TypeCompose";
+        version = "0.9.13";
+        src = ./.;
+        libraryHaskellDepends = [ base base-orphans cabal-install ];
+        homepage = "https://github.com/conal/TypeCompose";
+        description = "Type composition classes & instances";
+        license = stdenv.lib.licenses.bsd3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/src/Control/Compose.hs
+++ b/src/Control/Compose.hs
@@ -6,6 +6,9 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# Language DeriveGeneric #-}
 #endif
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 710
+{-# Language KindSignatures, PolyKinds #-}
+#endif
 -- For ghc 6.6 compatibility
 -- {-# OPTIONS -fglasgow-exts -fallow-undecidable-instances #-}
 
@@ -214,7 +217,12 @@ someday Haskell will do Prolog-style search for instances, subgoaling the
 constraints, rather than just matching instance heads.
 
 -}
-newtype (g :. f) a = O (g (f a)) deriving ( Eq, Show, Ord
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 710
+newtype ((g :: k2 -> *) :. (f :: k1 -> k2)) (a :: k1)
+#else
+newtype (g :. f) a
+#endif
+  = O (g (f a)) deriving ( Eq, Show, Ord
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
                                           , Generic
 #endif


### PR DESCRIPTION
This allows (:.) in a wider array of higher-kinded type scenarios.

Uses `PolyKinds` and `KindSignatures`.

Tested on GHC 8.4.